### PR TITLE
Enable CORS for all responses

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -17,6 +17,12 @@ include SportDb::Models
 ##############################################
 # Controllers / Routing / Request Handlers
 
+before do
+  headers 'Access-Control-Allow-Origin' => '*'
+  headers 'Access-Control-Allow-Headers' => 'Authorization,Accepts,Content-Type,X-CSRF-Token,X-Requested-With'
+  headers 'Access-Control-Allow-Methods' => 'GET,POST,PUT,DELETE,OPTIONS'
+end
+
 get '/' do
 
   ## self-docu in json


### PR DESCRIPTION
Cross-Origin Resource Sharing is a security setting to manage exceptions
to same-origin policy browsers implement. It's a modern and more secure
alternative to JSONP.
